### PR TITLE
Aligns instructions with program default behaviour

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -30,15 +30,15 @@ this already.
 
 To install the Automysqlbackup the easy way.
 1. Run the install.sh script.
-2. Edit the /etc/automysqlbackup/myserver.conf file to customise your settings.
+2. Edit the /etc/automysqlbackup/automysqlbackup.conf file to customise your settings.
 3. See usage section.
 
 To install it manually (the hard way).
 1. Create the /etc/automysqlbackup directory.
 2. Copy in the automysqlbackup.conf file.
 3. Copy the automysqlbackup file to /usr/local/bin and make executable.
-4. cp /etc/automysqlbackup/automysqlbackup.conf /etc/automysqlbackup/myserver.conf
-5. Edit the /etc/automysqlbackup/myserver.conf file to customise your settings.
+4. cp /etc/automysqlbackup/automysqlbackup.conf /etc/automysqlbackup/automysqlbackup.conf
+5. Edit the /etc/automysqlbackup/automysqlbackup.conf file to customise your settings.
 6. See usage section.
 
 

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -224,7 +224,7 @@ CONFIG_mailcontent='quiet'
 #CONFIG_mail_use_uuencoded_attachments='no'
 
 # Email Address to send mail to? (user@domain.com)
-CONFIG_mail_address='herson@paradisosolutions.com'
+CONFIG_mail_address=''
 
 
 # Encryption


### PR DESCRIPTION
Fixes "Note: /etc/automysqlbackup/automysqlbackup.conf was not found - no global config file."